### PR TITLE
feat: add custom booking roles and capabilities

### DIFF
--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -10,8 +10,9 @@ class Settings {
     }
 
     public static function menu() {
-        add_menu_page( 'AMCB', 'AMCB', 'manage_options', 'amcb-settings', [ __CLASS__, 'render' ], 'dashicons-car', 56 );
-        add_submenu_page( 'amcb-settings', __( 'Tools', 'amcb' ), __( 'Tools', 'amcb' ), 'manage_options', 'amcb-tools', [ Tools::class, 'render' ] );
+        // Only booking managers can access the settings pages.
+        add_menu_page( 'AMCB', 'AMCB', 'amcb_manage_bookings', 'amcb-settings', [ __CLASS__, 'render' ], 'dashicons-car', 56 );
+        add_submenu_page( 'amcb-settings', __( 'Tools', 'amcb' ), __( 'Tools', 'amcb' ), 'amcb_manage_bookings', 'amcb-tools', [ Tools::class, 'render' ] );
     }
     public static function settings() {
         register_setting('amcb', 'amcb_options');

--- a/src/Admin/Tools.php
+++ b/src/Admin/Tools.php
@@ -28,8 +28,13 @@ class Tools {
         <?php
     }
 
+    /**
+     * Run migrations action.
+     *
+     * Requires the `amcb_manage_bookings` capability.
+     */
     public static function run_migrations() {
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( 'amcb_manage_bookings' ) ) {
             wp_die( esc_html__( 'You are not allowed to perform this action.', 'amcb' ) );
         }
         check_admin_referer( 'amcb_run_migrations' );
@@ -38,8 +43,13 @@ class Tools {
         exit;
     }
 
+    /**
+     * Seed demo data action.
+     *
+     * Requires the `amcb_manage_bookings` capability.
+     */
     public static function create_demo() {
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( 'amcb_manage_bookings' ) ) {
             wp_die( esc_html__( 'You are not allowed to perform this action.', 'amcb' ) );
         }
         check_admin_referer( 'amcb_create_demo' );

--- a/src/Install/Activator.php
+++ b/src/Install/Activator.php
@@ -5,6 +5,7 @@
  * @package AMCB
  */
 // phpcs:ignoreFile
+
 namespace AMCB\Install;
 
 /**
@@ -13,15 +14,44 @@ namespace AMCB\Install;
 class Activator {
     /**
      * Run on plugin activation.
+     *
+     * Creates custom roles:
+     * - `amcb_customer` — basic read access.
+     * - `amcb_manager` — adds `amcb_manage_bookings` capability for booking management.
      */
     public static function activate() {
         Migrations::migrate();
+
+        // Basic customer role. Only grants read access.
+        add_role(
+            'amcb_customer',
+            __( 'Booking Customer', 'amcb' ),
+            array(
+                'read' => true,
+            )
+        );
+
+        // Manager role. Can manage plugin bookings and settings.
+        add_role(
+            'amcb_manager',
+            __( 'Booking Manager', 'amcb' ),
+            array(
+                'read'                 => true,
+                'amcb_manage_bookings' => true,
+            )
+        );
     }
 
     /**
      * Run on plugin deactivation.
+     *
+     * Removes custom roles.
      */
     public static function deactivate() {
         // Cleanup scheduled events if any.
+
+        remove_role( 'amcb_customer' );
+        remove_role( 'amcb_manager' );
     }
 }
+


### PR DESCRIPTION
## Summary
- add `amcb_customer` and `amcb_manager` roles with booking management capability
- restrict admin pages and tools to users with `amcb_manage_bookings`
- remove custom roles on plugin deactivation

## Testing
- `~/.local/share/mise/installs/php/8.3.24/.composer/vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Install`


------
https://chatgpt.com/codex/tasks/task_e_689d3c5c99e483338cbbe4e8ac0e6a98