### PR TITLE
feat: schedule cron events on activation

### DIFF
--- a/src/Install/Activator.php
+++ b/src/Install/Activator.php
@@ -22,6 +22,14 @@ class Activator {
     public static function activate() {
         Migrations::migrate();
 
+        if ( ! wp_next_scheduled( 'amcb_cron_minutely' ) ) {
+            wp_schedule_event( time(), 'amcb_minutely', 'amcb_cron_minutely' );
+        }
+
+        if ( ! wp_next_scheduled( 'amcb_cron_hourly' ) ) {
+            wp_schedule_event( time(), 'hourly', 'amcb_cron_hourly' );
+        }
+
         // Basic customer role. Only grants read access.
         add_role(
             'amcb_customer',
@@ -49,6 +57,8 @@ class Activator {
      */
     public static function deactivate() {
         // Cleanup scheduled events if any.
+        wp_clear_scheduled_hook( 'amcb_cron_minutely' );
+        wp_clear_scheduled_hook( 'amcb_cron_hourly' );
 
         remove_role( 'amcb_customer' );
         remove_role( 'amcb_manager' );

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -5,6 +5,10 @@ class Plugin {
     public static function init() {
         load_plugin_textdomain('amcb', false, dirname(plugin_basename(__FILE__)) . '/../languages');
 
+        add_filter( 'cron_schedules', [ __CLASS__, 'cron_schedules' ] );
+        add_action( 'amcb_cron_minutely', [ __CLASS__, 'cron_minutely' ] );
+        add_action( 'amcb_cron_hourly', [ __CLASS__, 'cron_hourly' ] );
+
         // Assets
         add_action('wp_enqueue_scripts', [__CLASS__, 'assets']);
         // Shortcodes
@@ -25,5 +29,22 @@ class Plugin {
         wp_register_style('amcb-frontend', plugins_url('../assets/css/frontend.css', __FILE__), [], $ver);
         wp_register_script('amcb-frontend', plugins_url('../assets/js/frontend.js', __FILE__), ['jquery'], $ver, true);
         wp_register_script('amcb-checkout', plugins_url('../assets/js/checkout.js', __FILE__), ['jquery'], $ver, true);
+    }
+
+    public static function cron_schedules( $schedules ) {
+        $schedules['amcb_minutely'] = array(
+            'interval' => MINUTE_IN_SECONDS,
+            'display'  => __( 'Every Minute', 'amcb' ),
+        );
+
+        return $schedules;
+    }
+
+    public static function cron_minutely() {
+        // Placeholder for minutely cron tasks.
+    }
+
+    public static function cron_hourly() {
+        // Placeholder for hourly cron tasks.
     }
 }


### PR DESCRIPTION
## Summary
- schedule `amcb_cron_minutely` and `amcb_cron_hourly` during activation
- register cron callbacks and add custom minutely interval
- clear scheduled hooks on deactivation

## Testing
- `~/.local/share/mise/installs/php/8.3.24/.composer/vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Install`


------
https://chatgpt.com/codex/tasks/task_e_689d3de95af083339a06b7bcc0963496