### PR TITLE
feat: add checkout price endpoint

### DIFF
--- a/src/Api/Rest.php
+++ b/src/Api/Rest.php
@@ -8,6 +8,7 @@
 namespace AMCB\Api;
 
 use AMCB\Front\Availability;
+use AMCB\Domain\Pricing;
 use WP_Error;
 use WP_REST_Request;
 
@@ -64,6 +65,65 @@ class Rest {
 								'required'          => false,
 								'sanitize_callback' => 'absint',
 								'default'           => 0,
+							),
+						),
+					)
+				);
+				register_rest_route(
+					'amcb/v1',
+					'/checkout/price',
+					array(
+						'methods'             => 'POST',
+						'callback'            => array( __CLASS__, 'checkout_price' ),
+						'permission_callback' => array( __CLASS__, 'check_permissions' ),
+						'args'                => array(
+							'vehicle_id'    => array(
+								'required'          => true,
+								'sanitize_callback' => 'absint',
+							),
+							'start_date'    => array(
+								'required'          => true,
+								'sanitize_callback' => 'sanitize_text_field',
+							),
+							'end_date'      => array(
+								'required'          => true,
+								'sanitize_callback' => 'sanitize_text_field',
+							),
+							'pickup_time'   => array(
+								'sanitize_callback' => 'sanitize_text_field',
+							),
+							'dropoff_time'  => array(
+								'sanitize_callback' => 'sanitize_text_field',
+							),
+							'pickup'        => array(
+								'sanitize_callback' => 'absint',
+							),
+							'dropoff'       => array(
+								'sanitize_callback' => 'absint',
+							),
+							'home_delivery' => array(
+								'sanitize_callback' => 'absint',
+								'default'           => 0,
+							),
+							'services'      => array(
+								'sanitize_callback' => function ( $value ) {
+									return array_map( 'absint', (array) $value );
+								},
+								'default'           => array(),
+							),
+							'insurance_id'  => array(
+								'sanitize_callback' => 'absint',
+							),
+							'coupon_code'   => array(
+								'sanitize_callback' => 'sanitize_text_field',
+							),
+							'payment_mode'  => array(
+								'sanitize_callback' => 'sanitize_text_field',
+								'default'           => 'full',
+							),
+							'currency'      => array(
+								'sanitize_callback' => 'sanitize_text_field',
+								'default'           => 'EUR',
 							),
 						),
 					)
@@ -162,5 +222,84 @@ class Rest {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Calculate pricing for checkout.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return array|WP_Error
+	 */
+	public static function checkout_price( WP_REST_Request $request ) {
+			$vehicle_id    = absint( $request->get_param( 'vehicle_id' ) );
+			$start_date    = sanitize_text_field( $request->get_param( 'start_date' ) );
+			$end_date      = sanitize_text_field( $request->get_param( 'end_date' ) );
+			$pickup_time   = sanitize_text_field( $request->get_param( 'pickup_time' ) );
+			$dropoff_time  = sanitize_text_field( $request->get_param( 'dropoff_time' ) );
+			$pickup        = absint( $request->get_param( 'pickup' ) );
+			$dropoff       = absint( $request->get_param( 'dropoff' ) );
+			$home_delivery = absint( $request->get_param( 'home_delivery' ) );
+			$services      = $request->get_param( 'services' );
+			$insurance_id  = absint( $request->get_param( 'insurance_id' ) );
+			$coupon_code   = sanitize_text_field( $request->get_param( 'coupon_code' ) );
+			$payment_mode  = sanitize_text_field( $request->get_param( 'payment_mode' ) );
+			$currency      = sanitize_text_field( $request->get_param( 'currency' ) );
+
+		if ( ! self::validate_date( $start_date ) || ! self::validate_date( $end_date ) ) {
+			return new WP_Error( 'invalid_date', __( 'Invalid date format.', 'amcb' ), array( 'status' => 400 ) );
+		}
+
+		if ( $start_date >= $end_date ) {
+			return new WP_Error( 'invalid_range', __( 'Start date must be before end date.', 'amcb' ), array( 'status' => 400 ) );
+		}
+
+		if ( $vehicle_id <= 0 ) {
+			return new WP_Error( 'invalid_vehicle', __( 'Invalid vehicle ID.', 'amcb' ), array( 'status' => 400 ) );
+		}
+
+		if ( ! in_array( $home_delivery, array( 0, 1 ), true ) ) {
+			return new WP_Error( 'invalid_home_delivery', __( 'Invalid home delivery value.', 'amcb' ), array( 'status' => 400 ) );
+		}
+
+		if ( ! in_array( $payment_mode, array( 'full', 'deposit' ), true ) ) {
+			return new WP_Error( 'invalid_payment_mode', __( 'Invalid payment mode.', 'amcb' ), array( 'status' => 400 ) );
+		}
+
+		if ( ! is_array( $services ) ) {
+			$services = array();
+		} else {
+			$services = array_map( 'absint', $services );
+		}
+
+			$pricing = new Pricing();
+			$result  = $pricing->calculate(
+				$vehicle_id,
+				$start_date,
+				$end_date,
+				$pickup_time,
+				$dropoff_time,
+				$pickup,
+				$dropoff,
+				$services,
+				$insurance_id,
+				$coupon_code,
+				$payment_mode,
+				$currency
+			);
+
+		if ( is_wp_error( $result ) ) {
+			$code = $result->get_error_code();
+			if ( in_array( $code, array( 'NO_RATE_COVERAGE', 'RENTAL_LENGTH_INVALID' ), true ) ) {
+				$data = $result->get_error_data();
+				if ( ! is_array( $data ) ) {
+					$data = array();
+				}
+				$data['status'] = 422;
+				return new WP_Error( $code, $result->get_error_message(), $data );
+			}
+			return $result;
+		}
+
+			return $result;
 	}
 }


### PR DESCRIPTION
## Summary
- add POST /amcb/v1/checkout/price REST endpoint
- compute pricing via Domain\Pricing::calculate with validation

## Testing
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Api/Rest.php`


------
https://chatgpt.com/codex/tasks/task_e_689de3df196c8333bff2ed6073b4890b