### PR TITLE
feat: add checkout price summary

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -4,7 +4,32 @@
     $('.amcb-step-'+step).attr('hidden', false);
     $('.amcb-steps span').removeClass('on').slice(0, step).addClass('on');
     $('.amcb-checkout-wizard').attr('data-step', step);
+    if(step === 4){ updateSummary(); }
     window.scrollTo({top:0,behavior:'smooth'});
+  }
+  function getContext(){
+    return $.extend({}, window.amcbCheckout?.context || {}, {
+      payment_mode: $('input[name="paymode"]:checked').val() || 'full'
+    });
+  }
+  function updateSummary(){
+    const ctx = getContext();
+    ctx._wpnonce = amcbCheckout.nonce;
+    fetch(amcbCheckout.restUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(ctx)
+    }).then(r => r.json()).then(data => {
+      const wrap = $('#amcb-summary');
+      wrap.find('.amcb-full').text(data.grand_total || '');
+      if(ctx.payment_mode === 'deposit'){
+        wrap.find('.amcb-deposit').text(data.deposit_amount || '');
+        wrap.find('.amcb-to-collect').text(data.to_collect || '');
+        wrap.find('.amcb-deposit-line, .amcb-to-collect-line').removeAttr('hidden');
+      } else {
+        wrap.find('.amcb-deposit-line, .amcb-to-collect-line').attr('hidden', true);
+      }
+    }).catch(()=>{});
   }
   $(document).on('click','.amcb-next',function(e){ e.preventDefault();
     const step = parseInt($('.amcb-checkout-wizard').attr('data-step'),10) + 1; goto(step);
@@ -13,4 +38,5 @@
     const step = Math.max(1, parseInt($('.amcb-checkout-wizard').attr('data-step'),10) - 1); goto(step);
   });
   $(document).on('change','.amcb-bill-toggle',function(){ $('.amcb-billing').attr('hidden', !this.checked); });
+  $(document).on('change','input[name="paymode"]',updateSummary);
 })(jQuery);

--- a/src/Front/Shortcodes.php
+++ b/src/Front/Shortcodes.php
@@ -149,21 +149,26 @@ class Shortcodes {
 						<button class="amcb-btn amcb-prev"><?php esc_html_e( 'Back', 'amcb' ); ?></button>
 						<button class="amcb-btn amcb-next"><?php esc_html_e( 'Continue', 'amcb' ); ?></button>
 						</div>
-						<div class="amcb-step amcb-step-4" hidden>
-						<h2><?php esc_html_e( 'Step 4: Summary and Payment', 'amcb' ); ?></h2>
-						<label><input type="radio" name="paymode" checked> <?php esc_html_e( 'Pay full amount', 'amcb' ); ?></label>
-						<label><input type="radio" name="paymode"> <?php esc_html_e( 'Pay a deposit (30%)', 'amcb' ); ?></label>
-						<div class="amcb-terms">
-								<label><input type="checkbox" required> <?php esc_html_e( 'I have read and agree to the Privacy Policy and Terms', 'amcb' ); ?></label>
-						</div>
-						<button class="amcb-btn amcb-prev"><?php esc_html_e( 'Back', 'amcb' ); ?></button>
-						<button class="amcb-btn amcb-next"><?php esc_html_e( 'Confirm and Pay', 'amcb' ); ?></button>
-						</div>
-						<div class="amcb-step amcb-step-5" hidden>
-						<h2><?php esc_html_e( 'Step 5: Secure Payment', 'amcb' ); ?></h2>
-						<div id="amcb-stripe-element"></div>
-						<button class="amcb-btn amcb-btn-success"><?php esc_html_e( 'Pay now', 'amcb' ); ?></button>
-						</div>
+                                               <div class="amcb-step amcb-step-4" hidden>
+                                               <h2><?php esc_html_e( 'Step 4: Summary and Payment', 'amcb' ); ?></h2>
+                                               <label><input type="radio" name="paymode" value="full" checked> <?php esc_html_e( 'Pay full amount', 'amcb' ); ?></label>
+                                               <label><input type="radio" name="paymode" value="deposit"> <?php esc_html_e( 'Pay a deposit (30%)', 'amcb' ); ?></label>
+                                               <div id="amcb-summary">
+                                                               <p><?php esc_html_e( 'Full', 'amcb' ); ?>: <span class="amcb-full"></span></p>
+                                                               <p class="amcb-deposit-line" hidden><?php esc_html_e( 'Deposit', 'amcb' ); ?>: <span class="amcb-deposit"></span></p>
+                                                               <p class="amcb-to-collect-line" hidden><?php esc_html_e( 'To collect', 'amcb' ); ?>: <span class="amcb-to-collect"></span></p>
+                                               </div>
+                                               <div class="amcb-terms">
+                                                               <label><input type="checkbox" required> <?php esc_html_e( 'I have read and agree to the Privacy Policy and Terms', 'amcb' ); ?></label>
+                                               </div>
+                                               <button class="amcb-btn amcb-prev"><?php esc_html_e( 'Back', 'amcb' ); ?></button>
+                                               <button class="amcb-btn amcb-next"><?php esc_html_e( 'Confirm and Pay', 'amcb' ); ?></button>
+                                               </div>
+                                               <div class="amcb-step amcb-step-5" hidden>
+                                               <h2><?php esc_html_e( 'Step 5: Secure Payment', 'amcb' ); ?></h2>
+                                               <div id="amcb-stripe-element"></div>
+                                               <button class="amcb-btn amcb-btn-success"><?php esc_html_e( 'Pay now', 'amcb' ); ?></button>
+                                               </div>
 				</div>
 				<?php
 				return ob_get_clean();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -56,9 +56,17 @@ class Plugin {
 	public static function assets() {
 		$ver = '0.1.0';
 		wp_register_style( 'amcb-frontend', plugins_url( '../assets/css/frontend.css', __FILE__ ), array(), $ver );
-		wp_register_script( 'amcb-frontend', plugins_url( '../assets/js/frontend.js', __FILE__ ), array( 'jquery' ), $ver, true );
-		wp_register_script( 'amcb-checkout', plugins_url( '../assets/js/checkout.js', __FILE__ ), array( 'jquery' ), $ver, true );
-	}
+               wp_register_script( 'amcb-frontend', plugins_url( '../assets/js/frontend.js', __FILE__ ), array( 'jquery' ), $ver, true );
+               wp_register_script( 'amcb-checkout', plugins_url( '../assets/js/checkout.js', __FILE__ ), array( 'jquery' ), $ver, true );
+               wp_localize_script(
+                       'amcb-checkout',
+                       'amcbCheckout',
+                       array(
+                               'restUrl' => esc_url_raw( rest_url( 'amcb/v1/checkout/price' ) ),
+                               'nonce'   => wp_create_nonce( 'wp_rest' ),
+                       )
+               );
+       }
 
 	/**
 	 * Register cron schedules.


### PR DESCRIPTION
## Summary
- add summary placeholders for full and deposit totals
- fetch price breakdown from REST API during checkout
- expose REST URL and nonce for checkout script

## Testing
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Front/Shortcodes.php assets/js/checkout.js`


------
https://chatgpt.com/codex/tasks/task_e_689df4b4811483338b5712c88bd418ca