### PR TITLE
feat: add admin menu

### DIFF
--- a/src/Admin/Menu.php
+++ b/src/Admin/Menu.php
@@ -1,0 +1,106 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotLowercase,WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Admin menu registration.
+ *
+ * @package AMCB
+ */
+
+namespace AMCB\Admin;
+
+use AMCB\Admin\Settings;
+use AMCB\Admin\Tools;
+
+/**
+ * Admin menu handler.
+ */
+class Menu {
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public static function register() {
+		add_action( 'admin_menu', array( __CLASS__, 'menu' ) );
+	}
+
+	/**
+	 * Add admin menu and submenus.
+	 *
+	 * @return void
+	 */
+	public static function menu() {
+		add_menu_page(
+			__( 'AMCB', 'amcb' ),
+			__( 'AMCB', 'amcb' ),
+			'amcb_manage_dashboard',
+			'amcb-dashboard',
+			array( __CLASS__, 'render_page' ),
+			'dashicons-car',
+			56
+		);
+
+		add_submenu_page(
+			'amcb-dashboard',
+			__( 'Dashboard', 'amcb' ),
+			__( 'Dashboard', 'amcb' ),
+			'amcb_manage_dashboard',
+			'amcb-dashboard',
+			array( __CLASS__, 'render_page' )
+		);
+
+		$sections = array(
+			'bookings'   => __( 'Bookings', 'amcb' ),
+			'vehicles'   => __( 'Vehicles', 'amcb' ),
+			'prices'     => __( 'Prices', 'amcb' ),
+			'blocks'     => __( 'Blocks', 'amcb' ),
+			'services'   => __( 'Services', 'amcb' ),
+			'insurances' => __( 'Insurances', 'amcb' ),
+			'coupons'    => __( 'Coupons', 'amcb' ),
+			'locations'  => __( 'Locations', 'amcb' ),
+		);
+
+		foreach ( $sections as $slug => $label ) {
+			add_submenu_page(
+				'amcb-dashboard',
+				$label,
+				$label,
+				"amcb_manage_{$slug}",
+				"amcb-{$slug}",
+				array( __CLASS__, 'render_page' )
+			);
+		}
+
+		add_submenu_page(
+			'amcb-dashboard',
+			__( 'Tools', 'amcb' ),
+			__( 'Tools', 'amcb' ),
+			'amcb_manage_tools',
+			'amcb-tools',
+			array( Tools::class, 'render' )
+		);
+
+		add_submenu_page(
+			'amcb-dashboard',
+			__( 'Settings', 'amcb' ),
+			__( 'Settings', 'amcb' ),
+			'amcb_manage_settings',
+			'amcb-settings',
+			array( Settings::class, 'render' )
+		);
+
+		remove_submenu_page( 'amcb-dashboard', 'amcb-dashboard' );
+	}
+
+	/**
+	 * Render stub page.
+	 *
+	 * @return void
+	 */
+	public static function render_page() {
+		?>
+		<div class="wrap">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+		</div>
+		<?php
+	}
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,8 +7,10 @@
 
 namespace AMCB;
 
+use AMCB\Admin\Menu;
 use AMCB\Admin\Roles;
 use AMCB\Admin\Settings;
+use AMCB\Admin\Tools;
 use AMCB\Api\Rest;
 use AMCB\Front\Shortcodes;
 
@@ -38,13 +40,15 @@ class Plugin {
 		add_action( 'elementor/widgets/register', array( 'AMCB\\Elementor\\Plugin', 'register_widgets' ) );
 		add_action( 'elementor/elements/categories_registered', array( 'AMCB\\Elementor\\Plugin', 'register_category' ) );
 
-		// REST.
-		Rest::register();
+				// REST.
+				Rest::register();
 
-		// Admin.
+				// Admin.
 		if ( is_admin() ) {
-			Settings::register();
-			add_action( 'admin_init', array( Roles::class, 'ensure_caps' ) );
+				Menu::register();
+				Tools::register();
+				add_action( 'admin_init', array( Settings::class, 'settings' ) );
+				add_action( 'admin_init', array( Roles::class, 'ensure_caps' ) );
 		}
 	}
 
@@ -54,19 +58,19 @@ class Plugin {
 	 * @return void
 	 */
 	public static function assets() {
-		$ver = '0.1.0';
-		wp_register_style( 'amcb-frontend', plugins_url( '../assets/css/frontend.css', __FILE__ ), array(), $ver );
-               wp_register_script( 'amcb-frontend', plugins_url( '../assets/js/frontend.js', __FILE__ ), array( 'jquery' ), $ver, true );
-               wp_register_script( 'amcb-checkout', plugins_url( '../assets/js/checkout.js', __FILE__ ), array( 'jquery' ), $ver, true );
-               wp_localize_script(
-                       'amcb-checkout',
-                       'amcbCheckout',
-                       array(
-                               'restUrl' => esc_url_raw( rest_url( 'amcb/v1/checkout/price' ) ),
-                               'nonce'   => wp_create_nonce( 'wp_rest' ),
-                       )
-               );
-       }
+			$ver = '0.1.0';
+			wp_register_style( 'amcb-frontend', plugins_url( '../assets/css/frontend.css', __FILE__ ), array(), $ver );
+			wp_register_script( 'amcb-frontend', plugins_url( '../assets/js/frontend.js', __FILE__ ), array( 'jquery' ), $ver, true );
+			wp_register_script( 'amcb-checkout', plugins_url( '../assets/js/checkout.js', __FILE__ ), array( 'jquery' ), $ver, true );
+			wp_localize_script(
+				'amcb-checkout',
+				'amcbCheckout',
+				array(
+					'restUrl' => esc_url_raw( rest_url( 'amcb/v1/checkout/price' ) ),
+					'nonce'   => wp_create_nonce( 'wp_rest' ),
+				)
+			);
+	}
 
 	/**
 	 * Register cron schedules.


### PR DESCRIPTION
## Summary
- add `Menu` class to register AMCB admin pages
- wire `Menu::register()` during plugin init

## Testing
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Admin/Menu.php src/Plugin.php`
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Plugin.php`

------
https://chatgpt.com/codex/tasks/task_e_689e024e4034833387823553ec64a558