### PR TITLE
feat: add admin list tables

### DIFF
--- a/src/Admin/ListTable/Blocks_Table.php
+++ b/src/Admin/ListTable/Blocks_Table.php
@@ -1,0 +1,60 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotLowercase, WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Blocks list table.
+ *
+ * @package AMCB
+ */
+
+namespace AMCB\Admin\ListTable;
+
+use WP_List_Table;
+
+/**
+ * Blocks list table.
+ */
+class Blocks_Table extends WP_List_Table {
+		/**
+		 * Prepare list table items.
+		 *
+		 * @return void
+		 */
+	public function prepare_items() {
+			$this->items           = array();
+			$this->_column_headers = array( $this->get_columns(), array(), array() );
+	}
+
+		/**
+		 * Get list table columns.
+		 *
+		 * @return array
+		 */
+	public function get_columns() {
+			return array(
+				'title' => __( 'Title', 'amcb' ),
+			);
+	}
+
+		/**
+		 * Render admin page.
+		 *
+		 * @return void
+		 */
+	public static function render() {
+		if ( ! current_user_can( 'amcb_manage_blocks' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				wp_die( esc_html__( 'You are not allowed to access this page.', 'amcb' ) );
+		}
+
+			$table = new self();
+			$table->prepare_items();
+		?>
+				<div class="wrap">
+						<h1 class="wp-heading-inline"><?php echo esc_html__( 'Blocks', 'amcb' ); ?></h1>
+						<a href="#" class="page-title-action"><?php echo esc_html__( 'Add New', 'amcb' ); ?></a>
+						<hr class="wp-header-end">
+						<form method="post">
+							<?php $table->display(); ?>
+						</form>
+				</div>
+				<?php
+	}
+}

--- a/src/Admin/ListTable/Bookings_Table.php
+++ b/src/Admin/ListTable/Bookings_Table.php
@@ -1,0 +1,60 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotLowercase, WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Bookings list table.
+ *
+ * @package AMCB
+ */
+
+namespace AMCB\Admin\ListTable;
+
+use WP_List_Table;
+
+/**
+ * Bookings list table.
+ */
+class Bookings_Table extends WP_List_Table {
+		/**
+		 * Prepare list table items.
+		 *
+		 * @return void
+		 */
+	public function prepare_items() {
+			$this->items           = array();
+			$this->_column_headers = array( $this->get_columns(), array(), array() );
+	}
+
+		/**
+		 * Get list table columns.
+		 *
+		 * @return array
+		 */
+	public function get_columns() {
+			return array(
+				'title' => __( 'Title', 'amcb' ),
+			);
+	}
+
+		/**
+		 * Render admin page.
+		 *
+		 * @return void
+		 */
+	public static function render() {
+		if ( ! current_user_can( 'amcb_manage_bookings' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				wp_die( esc_html__( 'You are not allowed to access this page.', 'amcb' ) );
+		}
+
+			$table = new self();
+			$table->prepare_items();
+		?>
+				<div class="wrap">
+						<h1 class="wp-heading-inline"><?php echo esc_html__( 'Bookings', 'amcb' ); ?></h1>
+						<a href="#" class="page-title-action"><?php echo esc_html__( 'Add New', 'amcb' ); ?></a>
+						<hr class="wp-header-end">
+						<form method="post">
+							<?php $table->display(); ?>
+						</form>
+				</div>
+				<?php
+	}
+}

--- a/src/Admin/ListTable/Coupons_Table.php
+++ b/src/Admin/ListTable/Coupons_Table.php
@@ -1,0 +1,60 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotLowercase, WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Coupons list table.
+ *
+ * @package AMCB
+ */
+
+namespace AMCB\Admin\ListTable;
+
+use WP_List_Table;
+
+/**
+ * Coupons list table.
+ */
+class Coupons_Table extends WP_List_Table {
+		/**
+		 * Prepare list table items.
+		 *
+		 * @return void
+		 */
+	public function prepare_items() {
+			$this->items           = array();
+			$this->_column_headers = array( $this->get_columns(), array(), array() );
+	}
+
+		/**
+		 * Get list table columns.
+		 *
+		 * @return array
+		 */
+	public function get_columns() {
+			return array(
+				'title' => __( 'Title', 'amcb' ),
+			);
+	}
+
+		/**
+		 * Render admin page.
+		 *
+		 * @return void
+		 */
+	public static function render() {
+		if ( ! current_user_can( 'amcb_manage_coupons' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				wp_die( esc_html__( 'You are not allowed to access this page.', 'amcb' ) );
+		}
+
+			$table = new self();
+			$table->prepare_items();
+		?>
+				<div class="wrap">
+						<h1 class="wp-heading-inline"><?php echo esc_html__( 'Coupons', 'amcb' ); ?></h1>
+						<a href="#" class="page-title-action"><?php echo esc_html__( 'Add New', 'amcb' ); ?></a>
+						<hr class="wp-header-end">
+						<form method="post">
+							<?php $table->display(); ?>
+						</form>
+				</div>
+				<?php
+	}
+}

--- a/src/Admin/ListTable/Insurances_Table.php
+++ b/src/Admin/ListTable/Insurances_Table.php
@@ -1,0 +1,60 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotLowercase, WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Insurances list table.
+ *
+ * @package AMCB
+ */
+
+namespace AMCB\Admin\ListTable;
+
+use WP_List_Table;
+
+/**
+ * Insurances list table.
+ */
+class Insurances_Table extends WP_List_Table {
+		/**
+		 * Prepare list table items.
+		 *
+		 * @return void
+		 */
+	public function prepare_items() {
+			$this->items           = array();
+			$this->_column_headers = array( $this->get_columns(), array(), array() );
+	}
+
+		/**
+		 * Get list table columns.
+		 *
+		 * @return array
+		 */
+	public function get_columns() {
+			return array(
+				'title' => __( 'Title', 'amcb' ),
+			);
+	}
+
+		/**
+		 * Render admin page.
+		 *
+		 * @return void
+		 */
+	public static function render() {
+		if ( ! current_user_can( 'amcb_manage_insurances' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				wp_die( esc_html__( 'You are not allowed to access this page.', 'amcb' ) );
+		}
+
+			$table = new self();
+			$table->prepare_items();
+		?>
+				<div class="wrap">
+						<h1 class="wp-heading-inline"><?php echo esc_html__( 'Insurances', 'amcb' ); ?></h1>
+						<a href="#" class="page-title-action"><?php echo esc_html__( 'Add New', 'amcb' ); ?></a>
+						<hr class="wp-header-end">
+						<form method="post">
+							<?php $table->display(); ?>
+						</form>
+				</div>
+				<?php
+	}
+}

--- a/src/Admin/ListTable/Locations_Table.php
+++ b/src/Admin/ListTable/Locations_Table.php
@@ -1,0 +1,60 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotLowercase, WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Locations list table.
+ *
+ * @package AMCB
+ */
+
+namespace AMCB\Admin\ListTable;
+
+use WP_List_Table;
+
+/**
+ * Locations list table.
+ */
+class Locations_Table extends WP_List_Table {
+		/**
+		 * Prepare list table items.
+		 *
+		 * @return void
+		 */
+	public function prepare_items() {
+			$this->items           = array();
+			$this->_column_headers = array( $this->get_columns(), array(), array() );
+	}
+
+		/**
+		 * Get list table columns.
+		 *
+		 * @return array
+		 */
+	public function get_columns() {
+			return array(
+				'title' => __( 'Title', 'amcb' ),
+			);
+	}
+
+		/**
+		 * Render admin page.
+		 *
+		 * @return void
+		 */
+	public static function render() {
+		if ( ! current_user_can( 'amcb_manage_locations' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				wp_die( esc_html__( 'You are not allowed to access this page.', 'amcb' ) );
+		}
+
+			$table = new self();
+			$table->prepare_items();
+		?>
+				<div class="wrap">
+						<h1 class="wp-heading-inline"><?php echo esc_html__( 'Locations', 'amcb' ); ?></h1>
+						<a href="#" class="page-title-action"><?php echo esc_html__( 'Add New', 'amcb' ); ?></a>
+						<hr class="wp-header-end">
+						<form method="post">
+							<?php $table->display(); ?>
+						</form>
+				</div>
+				<?php
+	}
+}

--- a/src/Admin/ListTable/Prices_Table.php
+++ b/src/Admin/ListTable/Prices_Table.php
@@ -1,0 +1,60 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotLowercase, WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Prices list table.
+ *
+ * @package AMCB
+ */
+
+namespace AMCB\Admin\ListTable;
+
+use WP_List_Table;
+
+/**
+ * Prices list table.
+ */
+class Prices_Table extends WP_List_Table {
+		/**
+		 * Prepare list table items.
+		 *
+		 * @return void
+		 */
+	public function prepare_items() {
+			$this->items           = array();
+			$this->_column_headers = array( $this->get_columns(), array(), array() );
+	}
+
+		/**
+		 * Get list table columns.
+		 *
+		 * @return array
+		 */
+	public function get_columns() {
+			return array(
+				'title' => __( 'Title', 'amcb' ),
+			);
+	}
+
+		/**
+		 * Render admin page.
+		 *
+		 * @return void
+		 */
+	public static function render() {
+		if ( ! current_user_can( 'amcb_manage_prices' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				wp_die( esc_html__( 'You are not allowed to access this page.', 'amcb' ) );
+		}
+
+			$table = new self();
+			$table->prepare_items();
+		?>
+				<div class="wrap">
+						<h1 class="wp-heading-inline"><?php echo esc_html__( 'Prices', 'amcb' ); ?></h1>
+						<a href="#" class="page-title-action"><?php echo esc_html__( 'Add New', 'amcb' ); ?></a>
+						<hr class="wp-header-end">
+						<form method="post">
+							<?php $table->display(); ?>
+						</form>
+				</div>
+				<?php
+	}
+}

--- a/src/Admin/ListTable/Services_Table.php
+++ b/src/Admin/ListTable/Services_Table.php
@@ -1,0 +1,60 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotLowercase, WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Services list table.
+ *
+ * @package AMCB
+ */
+
+namespace AMCB\Admin\ListTable;
+
+use WP_List_Table;
+
+/**
+ * Services list table.
+ */
+class Services_Table extends WP_List_Table {
+		/**
+		 * Prepare list table items.
+		 *
+		 * @return void
+		 */
+	public function prepare_items() {
+			$this->items           = array();
+			$this->_column_headers = array( $this->get_columns(), array(), array() );
+	}
+
+		/**
+		 * Get list table columns.
+		 *
+		 * @return array
+		 */
+	public function get_columns() {
+			return array(
+				'title' => __( 'Title', 'amcb' ),
+			);
+	}
+
+		/**
+		 * Render admin page.
+		 *
+		 * @return void
+		 */
+	public static function render() {
+		if ( ! current_user_can( 'amcb_manage_services' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				wp_die( esc_html__( 'You are not allowed to access this page.', 'amcb' ) );
+		}
+
+			$table = new self();
+			$table->prepare_items();
+		?>
+				<div class="wrap">
+						<h1 class="wp-heading-inline"><?php echo esc_html__( 'Services', 'amcb' ); ?></h1>
+						<a href="#" class="page-title-action"><?php echo esc_html__( 'Add New', 'amcb' ); ?></a>
+						<hr class="wp-header-end">
+						<form method="post">
+							<?php $table->display(); ?>
+						</form>
+				</div>
+				<?php
+	}
+}

--- a/src/Admin/ListTable/Vehicles_Table.php
+++ b/src/Admin/ListTable/Vehicles_Table.php
@@ -1,0 +1,60 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotLowercase, WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Vehicles list table.
+ *
+ * @package AMCB
+ */
+
+namespace AMCB\Admin\ListTable;
+
+use WP_List_Table;
+
+/**
+ * Vehicles list table.
+ */
+class Vehicles_Table extends WP_List_Table {
+		/**
+		 * Prepare list table items.
+		 *
+		 * @return void
+		 */
+	public function prepare_items() {
+			$this->items           = array();
+			$this->_column_headers = array( $this->get_columns(), array(), array() );
+	}
+
+		/**
+		 * Get list table columns.
+		 *
+		 * @return array
+		 */
+	public function get_columns() {
+			return array(
+				'title' => __( 'Title', 'amcb' ),
+			);
+	}
+
+		/**
+		 * Render admin page.
+		 *
+		 * @return void
+		 */
+	public static function render() {
+		if ( ! current_user_can( 'amcb_manage_vehicles' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				wp_die( esc_html__( 'You are not allowed to access this page.', 'amcb' ) );
+		}
+
+			$table = new self();
+			$table->prepare_items();
+		?>
+				<div class="wrap">
+						<h1 class="wp-heading-inline"><?php echo esc_html__( 'Vehicles', 'amcb' ); ?></h1>
+						<a href="#" class="page-title-action"><?php echo esc_html__( 'Add New', 'amcb' ); ?></a>
+						<hr class="wp-header-end">
+						<form method="post">
+							<?php $table->display(); ?>
+						</form>
+				</div>
+				<?php
+	}
+}


### PR DESCRIPTION
## Summary
- add placeholder WP_List_Table implementations for bookings, vehicles, prices, blocks, services, insurances, coupons, and locations

## Testing
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Admin/ListTable`

------
https://chatgpt.com/codex/tasks/task_e_689e2ba288f0833398bea19e35332040