### PR TITLE
feat: add admin assets and styles

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,11 @@
+.amcb-list-table .column-primary{
+    width:60%;
+}
+
+.amcb-settings-tabs{
+    margin-top:20px;
+}
+
+.amcb-settings-tabs .nav-tab-wrapper{
+    margin-bottom:20px;
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -49,6 +49,7 @@ class Plugin {
 				Tools::register();
 				add_action( 'admin_init', array( Settings::class, 'settings' ) );
 				add_action( 'admin_init', array( Roles::class, 'ensure_caps' ) );
+				add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_assets' ) );
 		}
 	}
 
@@ -70,6 +71,26 @@ class Plugin {
 					'nonce'   => wp_create_nonce( 'wp_rest' ),
 				)
 			);
+	}
+
+	/**
+	 * Register admin assets.
+	 *
+	 * @return void
+	 */
+	public static function admin_assets() {
+		$screen = get_current_screen();
+		if ( false === strpos( $screen->id, 'amcb' ) ) {
+			return;
+		}
+
+		$ver = '0.1.0';
+		wp_enqueue_style(
+			'amcb-admin',
+			plugins_url( '../assets/css/admin.css', __FILE__ ),
+			array(),
+			$ver
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- add admin enqueue hook and loader for new admin stylesheet
- style plugin list tables and settings tabs with admin.css

## Testing
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_689e2d23f5648333a49cce8cc5f06bff