### PR TITLE
fix: register demo seeder hook and make seeding idempotent

### DIFF
--- a/src/Install/DemoSeeder.php
+++ b/src/Install/DemoSeeder.php
@@ -28,28 +28,21 @@ class DemoSeeder {
 	/**
 	 * Run the demo seeder.
 	 *
-	 * Inserts demo vehicles, prices, insurances, services and locations.
-	 * Returns early if data already exists.
+         * Inserts demo vehicles, prices, insurances, services and locations.
+         * Safe to run multiple times without creating duplicates.
 	 *
 	 * @return void
 	 */
 	public static function run() {
 		global $wpdb;
 
-               $vehicle_table   = $wpdb->prefix . 'amcb_vehicles';
-               $price_table     = $wpdb->prefix . 'amcb_vehicle_prices';
-               $block_table     = $wpdb->prefix . 'amcb_vehicle_blocks';
-               $insurance_table = $wpdb->prefix . 'amcb_insurances';
-               $service_table   = $wpdb->prefix . 'amcb_services';
-               $coupon_table    = $wpdb->prefix . 'amcb_coupons';
-               $location_table  = $wpdb->prefix . 'amcb_locations';
-
-		$has_data = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$vehicle_table}" );
-
-		if ( $has_data > 0 ) {
-			esc_html_e( 'Demo data already seeded.', 'amcb' );
-			return;
-		}
+                $vehicle_table   = $wpdb->prefix . 'amcb_vehicles';
+                $price_table     = $wpdb->prefix . 'amcb_vehicle_prices';
+                $block_table     = $wpdb->prefix . 'amcb_vehicle_blocks';
+                $insurance_table = $wpdb->prefix . 'amcb_insurances';
+                $service_table   = $wpdb->prefix . 'amcb_services';
+                $coupon_table    = $wpdb->prefix . 'amcb_coupons';
+                $location_table  = $wpdb->prefix . 'amcb_locations';
 
 		// Vehicles.
 		$vehicles = array(
@@ -285,8 +278,6 @@ class DemoSeeder {
                        }
                }
 
-		esc_html_e( 'Demo data seeded.', 'amcb' );
-	}
+                return;
+        }
 }
-
-DemoSeeder::init();

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -13,6 +13,7 @@ use AMCB\Admin\Settings;
 use AMCB\Admin\Tools;
 use AMCB\Api\Rest;
 use AMCB\Front\Shortcodes;
+use AMCB\Install\DemoSeeder;
 
 /**
  * Main plugin class.
@@ -45,11 +46,12 @@ class Plugin {
 
 				// Admin.
 		if ( is_admin() ) {
-				Menu::register();
-				Tools::register();
-				add_action( 'admin_init', array( Settings::class, 'settings' ) );
-				add_action( 'admin_init', array( Roles::class, 'ensure_caps' ) );
-				add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_assets' ) );
+						DemoSeeder::init();
+						Menu::register();
+						Tools::register();
+						add_action( 'admin_init', array( Settings::class, 'settings' ) );
+						add_action( 'admin_init', array( Roles::class, 'ensure_caps' ) );
+						add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_assets' ) );
 		}
 	}
 


### PR DESCRIPTION
## Summary
- register demo seeder hook during admin init so tooling can seed demo data via `amcb_seed_demo`
- remove early exit and echoes from demo seeder; re-run safe without duplicating data

## Testing
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Install/DemoSeeder.php src/Plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_689e599303a88333ab235f02b15187f8