### PR TITLE
feat(admin): add diagnostics page

### DIFF
--- a/src/Admin/Diagnostics.php
+++ b/src/Admin/Diagnostics.php
@@ -1,0 +1,71 @@
+<?php // phpcs:ignore WordPress.Files.FileName.NotLowercase, WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Diagnostics admin page.
+ *
+ * @package AMCB
+ */
+
+namespace AMCB\Admin;
+
+/**
+ * Diagnostics page handler.
+ */
+class Diagnostics {
+	/**
+	 * Render diagnostics page.
+	 *
+	 * @return void
+	 */
+	public static function render() {
+		global $wpdb;
+
+		$tables = array(
+			'amcb_vehicles'       => __( 'Vehicles', 'amcb' ),
+			'amcb_vehicle_prices' => __( 'Vehicle Prices', 'amcb' ),
+			'amcb_insurances'     => __( 'Insurances', 'amcb' ),
+			'amcb_services'       => __( 'Services', 'amcb' ),
+			'amcb_locations'      => __( 'Locations', 'amcb' ),
+		);
+
+		$counts   = array();
+		$warnings = array();
+
+		foreach ( $tables as $table => $label ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$count            = (int) $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}{$table}" );
+			$counts[ $table ] = $count;
+			if ( 0 === $count ) {
+				$warnings[] = sprintf(
+				/* translators: %s: table label */
+					__( '%s table has no rows.', 'amcb' ),
+					$label
+				);
+			}
+		}
+		?>
+<div class="wrap">
+<h1><?php echo esc_html__( 'Diagnostics', 'amcb' ); ?></h1>
+		<?php foreach ( $warnings as $warning ) : ?>
+<div class="notice notice-warning"><p><?php echo esc_html( $warning ); ?></p></div>
+<?php endforeach; ?>
+<table class="widefat striped">
+<thead>
+<tr>
+<th><?php esc_html_e( 'Table', 'amcb' ); ?></th>
+<th><?php esc_html_e( 'Rows', 'amcb' ); ?></th>
+</tr>
+</thead>
+<tbody>
+		<?php foreach ( $tables as $table => $label ) : ?>
+<tr>
+<td><?php echo esc_html( $label ); ?></td>
+<td><?php echo esc_html( $counts[ $table ] ); ?></td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+</div>
+		<?php
+	}
+}
+

--- a/src/Admin/Menu.php
+++ b/src/Admin/Menu.php
@@ -7,6 +7,7 @@
 
 namespace AMCB\Admin;
 
+use AMCB\Admin\Diagnostics;
 use AMCB\Admin\Settings;
 use AMCB\Admin\Tools;
 
@@ -60,24 +61,33 @@ class Menu {
 		);
 
 		foreach ( $sections as $slug => $label ) {
-			add_submenu_page(
-				'amcb-dashboard',
-				$label,
-				$label,
-				"amcb_manage_{$slug}",
-				"amcb-{$slug}",
-				array( __CLASS__, 'render_page' )
-			);
+				add_submenu_page(
+					'amcb-dashboard',
+					$label,
+					$label,
+					"amcb_manage_{$slug}",
+					"amcb-{$slug}",
+					array( __CLASS__, 'render_page' )
+				);
 		}
 
-		add_submenu_page(
-			'amcb-dashboard',
-			__( 'Tools', 'amcb' ),
-			__( 'Tools', 'amcb' ),
-			'amcb_manage_tools',
-			'amcb-tools',
-			array( Tools::class, 'render' )
-		);
+				add_submenu_page(
+					'amcb-dashboard',
+					__( 'Diagnostics', 'amcb' ),
+					__( 'Diagnostics', 'amcb' ),
+					'amcb_manage_tools',
+					'amcb-diagnostics',
+					array( Diagnostics::class, 'render' )
+				);
+
+				add_submenu_page(
+					'amcb-dashboard',
+					__( 'Tools', 'amcb' ),
+					__( 'Tools', 'amcb' ),
+					'amcb_manage_tools',
+					'amcb-tools',
+					array( Tools::class, 'render' )
+				);
 
 		add_submenu_page(
 			'amcb-dashboard',


### PR DESCRIPTION
## Summary
- add diagnostics admin page to show row counts for key AMCB tables
- register Diagnostics submenu under AMCB menu

## Testing
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Admin/Diagnostics.php src/Admin/Menu.php`

------
https://chatgpt.com/codex/tasks/task_e_689e5af824f8833393ac9dd02f7579bc