### PR TITLE
fix(results): normalize date param names

### DIFF
--- a/assets/js/results.js
+++ b/assets/js/results.js
@@ -1,23 +1,44 @@
-(function($){
-  $(function(){
-    var cfg = window.amcbResults || {};
-    var container = $('#amcb-results');
-    var params = Object.fromEntries(new URLSearchParams(window.location.search));
-    params._wpnonce = cfg.nonce;
-    $.ajax({
-      url: cfg.restUrl,
-      method: 'GET',
-      data: params,
-      beforeSend: function(xhr){
-        xhr.setRequestHeader('X-WP-Nonce', cfg.nonce);
-      }
-    }).done(function(res){
-      if(!Array.isArray(res)) return;
-      res.sort(function(a,b){ return a.name.localeCompare(b.name); });
-      var html = res.map(function(v){
-        return '<div class="amcb-vehicle-card"><div class="amcb-vehicle-body"><h3>'+v.name+'</h3></div></div>';
-      }).join('');
-      container.html(html);
-    });
-  });
-})(jQuery);
+(function ($) {
+	$(
+		function () {
+			var cfg       = window.amcbResults || {};
+			var container = $( '#amcb-results' );
+			var params    = Object.fromEntries( new URLSearchParams( window.location.search ) );
+			if (params.pickup_date) {
+				params.start_date = params.pickup_date;
+				delete params.pickup_date;
+			}
+			if (params.dropoff_date) {
+				params.end_date = params.dropoff_date;
+				delete params.dropoff_date;
+			}
+			params._wpnonce = cfg.nonce;
+			$.ajax(
+				{
+					url: cfg.restUrl,
+					method: 'GET',
+					data: params,
+					beforeSend: function (xhr) {
+						xhr.setRequestHeader( 'X-WP-Nonce', cfg.nonce );
+					}
+				}
+			).done(
+				function (res) {
+					if ( ! Array.isArray( res )) {
+						return;
+					}
+					res.sort(
+						function (a,b) {
+							return a.name.localeCompare( b.name ); }
+					);
+					var html = res.map(
+						function (v) {
+							return '<div class="amcb-vehicle-card"><div class="amcb-vehicle-body"><h3>' + v.name + '</h3></div></div>';
+						}
+					).join( '' );
+					container.html( html );
+				}
+			);
+		}
+	);
+})( jQuery );


### PR DESCRIPTION
## Summary
- map `pickup_date`/`dropoff_date` to `start_date`/`end_date` for results API
- drop redundant aliases before AJAX request
- lint results script to WordPress coding standards

## Testing
- `./vendor/bin/phpcs -p --standard=WordPress --extensions=php assets/js/results.js`
- `./vendor/bin/phpcs -p --standard=WordPress-Extra --extensions=js assets/js/results.js`


------
https://chatgpt.com/codex/tasks/task_e_689e5e6487c8833382375d4a0e61e7b5