### PR TITLE
feat(elementor): add checkout, dashboard and rates widgets

### DIFF
--- a/src/Elementor/Plugin.php
+++ b/src/Elementor/Plugin.php
@@ -5,15 +5,21 @@ namespace AMCB\Elementor;
 class Plugin {
     public static function register_category( $elements_manager ) {
         $elements_manager->add_category( 'amcb', [
-            'title' => 'AMCB (Totaliweb)',
+            'title' => __( 'AMCB (Totaliweb)', 'amcb' ),
             'icon'  => 'fa fa-plug',
         ] );
     }
     public static function register_widgets($widgets_manager){
         require_once __DIR__ . '/Widgets/Search.php';
         require_once __DIR__ . '/Widgets/Results.php';
+        require_once __DIR__ . '/Widgets/Checkout.php';
+        require_once __DIR__ . '/Widgets/Dashboard.php';
+        require_once __DIR__ . '/Widgets/Rates.php';
 
         $widgets_manager->register( new \AMCB\Elementor\Widgets\Search() );
         $widgets_manager->register( new \AMCB\Elementor\Widgets\Results() );
+        $widgets_manager->register( new \AMCB\Elementor\Widgets\Checkout() );
+        $widgets_manager->register( new \AMCB\Elementor\Widgets\Dashboard() );
+        $widgets_manager->register( new \AMCB\Elementor\Widgets\Rates() );
     }
 }

--- a/src/Elementor/Widgets/Checkout.php
+++ b/src/Elementor/Widgets/Checkout.php
@@ -1,0 +1,21 @@
+<?php
+// phpcs:ignoreFile
+namespace AMCB\Elementor\Widgets;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+class Checkout extends Widget_Base {
+    public function get_name() { return 'amcb-checkout'; }
+    public function get_title() { return __( 'AMCB – Checkout', 'amcb' ); }
+    public function get_icon() { return 'eicon-cart'; }
+    public function get_categories() { return [ 'amcb' ]; }
+    protected function register_controls() {
+        $this->start_controls_section( 'content', [ 'label' => __( 'Content', 'amcb' ) ] );
+        $this->add_control( 'title', [ 'label' => __( 'Title', 'amcb' ), 'type' => Controls_Manager::TEXT, 'default' => __( 'Checkout', 'amcb' ) ] );
+        $this->end_controls_section();
+    }
+    protected function render() {
+        echo do_shortcode( '[amcb_checkout]' );
+    }
+}

--- a/src/Elementor/Widgets/Dashboard.php
+++ b/src/Elementor/Widgets/Dashboard.php
@@ -1,0 +1,21 @@
+<?php
+// phpcs:ignoreFile
+namespace AMCB\Elementor\Widgets;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+class Dashboard extends Widget_Base {
+    public function get_name() { return 'amcb-dashboard'; }
+    public function get_title() { return __( 'AMCB – Dashboard', 'amcb' ); }
+    public function get_icon() { return 'eicon-user-circle-o'; }
+    public function get_categories() { return [ 'amcb' ]; }
+    protected function register_controls() {
+        $this->start_controls_section( 'content', [ 'label' => __( 'Content', 'amcb' ) ] );
+        $this->add_control( 'title', [ 'label' => __( 'Title', 'amcb' ), 'type' => Controls_Manager::TEXT, 'default' => __( 'Dashboard', 'amcb' ) ] );
+        $this->end_controls_section();
+    }
+    protected function render() {
+        echo do_shortcode( '[amcb_dashboard]' );
+    }
+}

--- a/src/Elementor/Widgets/Rates.php
+++ b/src/Elementor/Widgets/Rates.php
@@ -1,0 +1,21 @@
+<?php
+// phpcs:ignoreFile
+namespace AMCB\Elementor\Widgets;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+class Rates extends Widget_Base {
+    public function get_name() { return 'amcb-rates'; }
+    public function get_title() { return __( 'AMCB – Rates', 'amcb' ); }
+    public function get_icon() { return 'eicon-table'; }
+    public function get_categories() { return [ 'amcb' ]; }
+    protected function register_controls() {
+        $this->start_controls_section( 'content', [ 'label' => __( 'Content', 'amcb' ) ] );
+        $this->add_control( 'title', [ 'label' => __( 'Title', 'amcb' ), 'type' => Controls_Manager::TEXT, 'default' => __( 'Rates', 'amcb' ) ] );
+        $this->end_controls_section();
+    }
+    protected function render() {
+        echo do_shortcode( '[amcb_tariffe]' );
+    }
+}

--- a/src/Elementor/Widgets/Results.php
+++ b/src/Elementor/Widgets/Results.php
@@ -6,16 +6,16 @@ use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 
 class Results extends Widget_Base {
-    public function get_name(){ return 'amcb-results'; }
-    public function get_title(){ return 'AMCB – Results'; }
-    public function get_icon(){ return 'eicon-post-list'; }
-    public function get_categories(){ return ['amcb']; }
+    public function get_name() { return 'amcb-results'; }
+    public function get_title() { return __( 'AMCB – Results', 'amcb' ); }
+    public function get_icon() { return 'eicon-post-list'; }
+    public function get_categories() { return [ 'amcb' ]; }
     protected function register_controls() {
-        $this->start_controls_section('content', ['label'=>'Content']);
-        $this->add_control('title', ['label'=>'Title','type'=>Controls_Manager::TEXT,'default'=>'Results']);
+        $this->start_controls_section( 'content', [ 'label' => __( 'Content', 'amcb' ) ] );
+        $this->add_control( 'title', [ 'label' => __( 'Title', 'amcb' ), 'type' => Controls_Manager::TEXT, 'default' => __( 'Results', 'amcb' ) ] );
         $this->end_controls_section();
     }
     protected function render() {
-        echo do_shortcode('[amcb_results]');
+        echo do_shortcode( '[amcb_results]' );
     }
 }

--- a/src/Elementor/Widgets/Search.php
+++ b/src/Elementor/Widgets/Search.php
@@ -6,16 +6,16 @@ use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 
 class Search extends Widget_Base {
-    public function get_name(){ return 'amcb-search'; }
-    public function get_title(){ return 'AMCB – Search'; }
-    public function get_icon(){ return 'eicon-search'; }
-    public function get_categories(){ return ['amcb']; }
+    public function get_name() { return 'amcb-search'; }
+    public function get_title() { return __( 'AMCB – Search', 'amcb' ); }
+    public function get_icon() { return 'eicon-search'; }
+    public function get_categories() { return [ 'amcb' ]; }
     protected function register_controls() {
-        $this->start_controls_section('content', ['label'=>'Content']);
-        $this->add_control('title', ['label'=>'Title','type'=>Controls_Manager::TEXT,'default'=>"Noleggia un'auto o scooter a Ischia"]);
+        $this->start_controls_section( 'content', [ 'label' => __( 'Content', 'amcb' ) ] );
+        $this->add_control( 'title', [ 'label' => __( 'Title', 'amcb' ), 'type' => Controls_Manager::TEXT, 'default' => __( 'Rent a car or scooter in Ischia', 'amcb' ) ] );
         $this->end_controls_section();
     }
     protected function render() {
-        echo do_shortcode('[amcb_search]');
+        echo do_shortcode( '[amcb_search]' );
     }
 }


### PR DESCRIPTION
## Summary
- add Elementor widgets for Checkout, Dashboard, and Rates shortcodes
- register new widgets within Elementor plugin
- improve widget i18n and update search default text

## Testing
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Elementor/Plugin.php src/Elementor/Widgets`


------
https://chatgpt.com/codex/tasks/task_e_689e5f468b088333b86320fa2148a8be