### PR TITLE
fix: update demo seeder locations

### DIFF
--- a/src/Install/DemoSeeder.php
+++ b/src/Install/DemoSeeder.php
@@ -247,17 +247,17 @@ class DemoSeeder {
                        }
                }
 
-		// Locations.
-		$locations = array(
-			array(
-				'name'    => 'Ischia Port',
-				'address' => 'Ischia, Italy',
-			),
-			array(
-				'name'    => 'Forio Port',
-				'address' => 'Forio, Italy',
-			),
-		);
+                // Locations.
+                $locations = array(
+                        array(
+                                'name'    => 'Ischia Porto',
+                                'address' => 'Ischia, Italy',
+                        ),
+                        array(
+                                'name'    => 'Forio',
+                                'address' => 'Forio, Italy',
+                        ),
+                );
 
                foreach ( $locations as $location ) {
                        $exists = (int) $wpdb->get_var(


### PR DESCRIPTION
## Summary
- rename demo location names to "Ischia Porto" and "Forio"
- ensure duplicate-check query uses updated names

## Testing
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Install/DemoSeeder.php`


------
https://chatgpt.com/codex/tasks/task_e_689ef49930848333baa5ea86dabb3237