### PR TITLE
feat: add vehicle creation handler

### DIFF
--- a/src/Admin/Vehicles.php
+++ b/src/Admin/Vehicles.php
@@ -13,24 +13,50 @@ use AMCB\Admin\ListTable\Vehicles_Table;
  * Vehicles page handler.
  */
 class Vehicles {
-	/**
-	 * Render vehicles page.
-	 *
-	 * @return void
-	 */
+
+		/**
+		 * Register admin actions.
+		 *
+		 * @return void
+		 */
+	public static function register() {
+			add_action( 'admin_post_amcb_add_vehicle', array( __CLASS__, 'add_vehicle' ) );
+	}
+
+		/**
+		 * Render vehicles page.
+		 *
+		 * @return void
+		 */
 	public static function render() {
 		if ( ! current_user_can( 'amcb_manage_vehicles' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
-			wp_die( esc_html__( 'You are not allowed to access this page.', 'amcb' ) );
+				wp_die( esc_html__( 'You are not allowed to access this page.', 'amcb' ) );
 		}
 
-		$action = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['amcb_notice'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					$notice   = sanitize_key( wp_unslash( $_GET['amcb_notice'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					$messages = array(
+						'vehicle_added' => __( 'Vehicle added.', 'amcb' ),
+					);
+
+					if ( isset( $messages[ $notice ] ) ) {
+						printf(
+							'<div class="notice notice-success"><p>%s</p></div>',
+							esc_html( $messages[ $notice ] )
+						);
+					}
+		}
+
+			$action = isset( $_GET['action'] ) ? sanitize_key( wp_unslash( $_GET['action'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ( 'add' === $action ) {
 			?>
 <div class="wrap">
 <h1 class="wp-heading-inline"><?php echo esc_html__( 'Add Vehicle', 'amcb' ); ?></h1>
 <hr class="wp-header-end">
-<form method="post">
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+			<?php wp_nonce_field( 'amcb_add_vehicle' ); ?>
+<input type="hidden" name="action" value="amcb_add_vehicle" />
 <table class="form-table">
 <tr>
 <th scope="row"><label for="amcb_name"><?php esc_html_e( 'Name', 'amcb' ); ?></label></th>
@@ -60,27 +86,27 @@ class Vehicles {
 			<?php for ( $i = 1; $i <= 2; $i++ ) : ?>
 <tr>
 <th scope="row">
-				<?php
-				/* translators: %d: season number */
-				echo esc_html( sprintf( __( 'Season %d', 'amcb' ), $i ) );
-				?>
+						<?php
+						/* translators: %d: season number */
+						echo esc_html( sprintf( __( 'Season %d', 'amcb' ), $i ) );
+						?>
 </th>
 <td>
 <label>
-				<?php esc_html_e( 'From', 'amcb' ); ?>
+						<?php esc_html_e( 'From', 'amcb' ); ?>
 <input type="date" name="season[<?php echo (int) $i; ?>][date_from]" />
 </label>
 <label>
-				<?php esc_html_e( 'To', 'amcb' ); ?>
+						<?php esc_html_e( 'To', 'amcb' ); ?>
 <input type="date" name="season[<?php echo (int) $i; ?>][date_to]" />
 </label>
 <label>
-				<?php esc_html_e( 'Price per day', 'amcb' ); ?>
+						<?php esc_html_e( 'Price per day', 'amcb' ); ?>
 <input type="number" step="0.01" name="season[<?php echo (int) $i; ?>][price_per_day]" />
 </label>
 </td>
 </tr>
-<?php endfor; ?>
+			<?php endfor; ?>
 <tr>
 <th scope="row"><label for="amcb_premium_insurance"><?php esc_html_e( 'Premium insurance price', 'amcb' ); ?></label></th>
 <td><input type="number" step="0.01" name="premium_insurance_price" id="amcb_premium_insurance" /></td>
@@ -89,11 +115,143 @@ class Vehicles {
 			<?php submit_button( __( 'Save Vehicle', 'amcb' ) ); ?>
 </form>
 </div>
-			<?php
-			return;
+						<?php
+						return;
 		}
 
-		Vehicles_Table::render();
+				Vehicles_Table::render();
+	}
+
+		/**
+		 * Handle vehicle addition.
+		 *
+		 * @return void
+		 */
+	public static function add_vehicle() {
+			check_admin_referer( 'amcb_add_vehicle' );
+
+		if ( ! current_user_can( 'amcb_manage_vehicles' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+				wp_die( esc_html__( 'You are not allowed to perform this action.', 'amcb' ) );
+		}
+
+			$name              = isset( $_POST['name'] ) ? sanitize_text_field( wp_unslash( $_POST['name'] ) ) : '';
+			$type              = isset( $_POST['type'] ) ? sanitize_text_field( wp_unslash( $_POST['type'] ) ) : '';
+			$stock_total       = isset( $_POST['stock_total'] ) ? absint( $_POST['stock_total'] ) : 0;
+			$featured          = isset( $_POST['featured'] ) ? 1 : 0;
+			$featured_priority = isset( $_POST['featured_priority'] ) ? absint( $_POST['featured_priority'] ) : 0;
+			$premium_price     = isset( $_POST['premium_insurance_price'] ) ? (float) $_POST['premium_insurance_price'] : 0.0;
+
+		$seasons_input = isset( $_POST['season'] ) ? wp_unslash( $_POST['season'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$seasons   = array();
+
+		for ( $i = 1; $i <= 2; $i++ ) {
+			if ( empty( $seasons_input[ $i ] ) ) {
+				continue;
+			}
+
+					$date_from = isset( $seasons_input[ $i ]['date_from'] ) ? sanitize_text_field( $seasons_input[ $i ]['date_from'] ) : '';
+					$date_to   = isset( $seasons_input[ $i ]['date_to'] ) ? sanitize_text_field( $seasons_input[ $i ]['date_to'] ) : '';
+					$price     = isset( $seasons_input[ $i ]['price_per_day'] ) ? $seasons_input[ $i ]['price_per_day'] : '';
+
+			if ( empty( $date_from ) || empty( $date_to ) || false === strtotime( $date_from ) || false === strtotime( $date_to ) || strtotime( $date_from ) > strtotime( $date_to ) ) {
+				wp_die( esc_html__( 'Invalid date range.', 'amcb' ) );
+			}
+
+			if ( ! is_numeric( $price ) ) {
+					wp_die( esc_html__( 'Invalid price.', 'amcb' ) );
+			}
+
+						$seasons[] = array(
+							'date_from' => $date_from,
+							'date_to'   => $date_to,
+							'price'     => (float) $price,
+						);
+		}
+
+			global $wpdb;
+			$vehicle_table   = $wpdb->prefix . 'amcb_vehicles';
+			$price_table     = $wpdb->prefix . 'amcb_vehicle_prices';
+			$insurance_table = $wpdb->prefix . 'amcb_insurances';
+
+			$wpdb->insert(
+				$vehicle_table,
+				array(
+					'name'              => $name,
+					'type'              => $type,
+					'stock_total'       => $stock_total,
+					'featured'          => $featured,
+					'featured_priority' => $featured_priority,
+				),
+				array(
+					'%s',
+					'%s',
+					'%d',
+					'%d',
+					'%d',
+				)
+			);
+
+			$vehicle_id = (int) $wpdb->insert_id;
+
+		foreach ( $seasons as $season ) {
+			$wpdb->insert(
+				$price_table,
+				array(
+					'vehicle_id' => $vehicle_id,
+					'date_from'  => $season['date_from'],
+					'date_to'    => $season['date_to'],
+					'price'      => $season['price'],
+				),
+				array(
+					'%d',
+					'%s',
+					'%s',
+					'%f',
+				)
+			);
+		}
+
+			$wpdb->insert(
+				$insurance_table,
+				array(
+					'vehicle_id' => $vehicle_id,
+					'name'       => 'Basic',
+					'price'      => 0,
+					'is_default' => 1,
+				),
+				array(
+					'%d',
+					'%s',
+					'%f',
+					'%d',
+				)
+			);
+
+			$wpdb->insert(
+				$insurance_table,
+				array(
+					'vehicle_id' => $vehicle_id,
+					'name'       => 'Premium',
+					'price'      => $premium_price,
+					'is_default' => 0,
+				),
+				array(
+					'%d',
+					'%s',
+					'%f',
+					'%d',
+				)
+			);
+
+			$redirect = add_query_arg(
+				array(
+					'page'        => 'amcb-vehicles',
+					'amcb_notice' => 'vehicle_added',
+				),
+				admin_url( 'admin.php' )
+			);
+			wp_safe_redirect( $redirect );
+			exit;
 	}
 }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -11,6 +11,7 @@ use AMCB\Admin\Menu;
 use AMCB\Admin\Roles;
 use AMCB\Admin\Settings;
 use AMCB\Admin\Tools;
+use AMCB\Admin\Vehicles;
 use AMCB\Api\Rest;
 use AMCB\Front\Shortcodes;
 use AMCB\Install\DemoSeeder;
@@ -19,6 +20,7 @@ use AMCB\Install\DemoSeeder;
  * Main plugin class.
  */
 class Plugin {
+
 	/**
 	 * Initialize plugin.
 	 *
@@ -41,17 +43,18 @@ class Plugin {
 		add_action( 'elementor/widgets/register', array( 'AMCB\\Elementor\\Plugin', 'register_widgets' ) );
 		add_action( 'elementor/elements/categories_registered', array( 'AMCB\\Elementor\\Plugin', 'register_category' ) );
 
-				// REST.
-				Rest::register();
+		// REST.
+		Rest::register();
 
-				// Admin.
+		// Admin.
 		if ( is_admin() ) {
-						DemoSeeder::init();
+			DemoSeeder::init();
 						Menu::register();
+						Vehicles::register();
 						Tools::register();
-						add_action( 'admin_init', array( Settings::class, 'settings' ) );
-						add_action( 'admin_init', array( Roles::class, 'ensure_caps' ) );
-						add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_assets' ) );
+			add_action( 'admin_init', array( Settings::class, 'settings' ) );
+			add_action( 'admin_init', array( Roles::class, 'ensure_caps' ) );
+			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_assets' ) );
 		}
 	}
 
@@ -61,18 +64,18 @@ class Plugin {
 	 * @return void
 	 */
 	public static function assets() {
-			$ver = '0.1.0';
-			wp_register_style( 'amcb-frontend', plugins_url( '../assets/css/frontend.css', __FILE__ ), array(), $ver );
-			wp_register_script( 'amcb-frontend', plugins_url( '../assets/js/frontend.js', __FILE__ ), array( 'jquery' ), $ver, true );
-			wp_register_script( 'amcb-checkout', plugins_url( '../assets/js/checkout.js', __FILE__ ), array( 'jquery' ), $ver, true );
-			wp_localize_script(
-				'amcb-checkout',
-				'amcbCheckout',
-				array(
-					'restUrl' => esc_url_raw( rest_url( 'amcb/v1/checkout/price' ) ),
-					'nonce'   => wp_create_nonce( 'wp_rest' ),
-				)
-			);
+		$ver = '0.1.0';
+		wp_register_style( 'amcb-frontend', plugins_url( '../assets/css/frontend.css', __FILE__ ), array(), $ver );
+		wp_register_script( 'amcb-frontend', plugins_url( '../assets/js/frontend.js', __FILE__ ), array( 'jquery' ), $ver, true );
+		wp_register_script( 'amcb-checkout', plugins_url( '../assets/js/checkout.js', __FILE__ ), array( 'jquery' ), $ver, true );
+		wp_localize_script(
+			'amcb-checkout',
+			'amcbCheckout',
+			array(
+				'restUrl' => esc_url_raw( rest_url( 'amcb/v1/checkout/price' ) ),
+				'nonce'   => wp_create_nonce( 'wp_rest' ),
+			)
+		);
 	}
 
 	/**
@@ -98,7 +101,7 @@ class Plugin {
 	/**
 	 * Register cron schedules.
 	 *
-	 * @param array $schedules Schedules.
+	 * @param  array $schedules Schedules.
 	 * @return array
 	 */
 	public static function cron_schedules( $schedules ) {


### PR DESCRIPTION
## Summary
- handle `admin_post_amcb_add_vehicle` to create vehicles with seasonal prices and insurances
- show success notice on Vehicles admin page
- wire controller into plugin bootstrap

## Testing
- `vendor/bin/phpcs --standard=WordPress src/Admin/Vehicles.php src/Plugin.php`


------
https://chatgpt.com/codex/tasks/task_e_689f347bd1488333babdd6acbaf810fe