### PR TITLE
feat: add session hold column and refresh migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Custom WordPress booking plugin for **Costabilerent** (car & scooter).
    - Dashboard: `[amcb_dashboard]`
    - Rates: `[amcb_tariffe]`
 
+## Upgrade
+
+Deactivate and reactivate the plugin after updating to rerun database migrations. This refreshes the `amcb_db_version` option and applies schema changes (e.g. DB **1.2.0** adds a `hold_until` column to `amcb_bookings` for session holds).
+
 ## Coding standards & i18n
 - WPCS/PHPCS:  
   `phpcs -p --standard=WordPress --extensions=php am-easy-custom-booking.php src`

--- a/src/Install/Activator.php
+++ b/src/Install/Activator.php
@@ -21,6 +21,7 @@ class Activator {
      */
     public static function activate() {
         Migrations::migrate();
+        update_option( 'amcb_db_version', Migrations::DB_VERSION );
 
         if ( ! wp_next_scheduled( 'amcb_cron_minutely' ) ) {
             wp_schedule_event( time(), 'amcb_minutely', 'amcb_cron_minutely' );


### PR DESCRIPTION
## Summary
- add `hold_until` field to `amcb_bookings`
- bump DB version and always run `dbDelta` migrations
- refresh stored `amcb_db_version` on activation and document upgrade steps

## Testing
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Install/Migrations.php`


------
https://chatgpt.com/codex/tasks/task_e_689f42e564908333a059a335918c5a7f