### PR TITLE
feat: prepare checkout session hold

### DIFF
--- a/assets/js/checkout.js
+++ b/assets/js/checkout.js
@@ -1,4 +1,8 @@
 (function($){
+  const { __ } = wp.i18n;
+
+  let holdTimer = null;
+
   function goto(step){
     $('.amcb-step').attr('hidden', true);
     $('.amcb-step-'+step).attr('hidden', false);
@@ -31,8 +35,66 @@
       }
     }).catch(()=>{});
   }
+  function startHoldCountdown(expiresAt){
+    const expiry = new Date(expiresAt).getTime();
+
+    if(!$('#amcb-summary .amcb-hold-timer').length){
+      $('#amcb-summary').append('<p class="amcb-hold-timer">'+ __("Time remaining",'amcb') +': <span></span></p>');
+    }
+    if(!$('.amcb-step-5 .amcb-hold-timer').length){
+      $('.amcb-step-5').prepend('<p class="amcb-hold-timer">'+ __("Time remaining",'amcb') +': <span></span></p>');
+    }
+
+    const spans = $('.amcb-hold-timer span');
+
+    function tick(){
+      const diff = Math.max(0, Math.floor((expiry - Date.now()) / 1000));
+      const min = String(Math.floor(diff / 60)).padStart(2,'0');
+      const sec = String(diff % 60).padStart(2,'0');
+      spans.text(min+':'+sec);
+      if(diff <= 0){
+        clearInterval(holdTimer);
+        spans.text(__('Expired','amcb'));
+        $('.amcb-btn-success').prop('disabled', true);
+      }
+    }
+
+    tick();
+    holdTimer = setInterval(tick,1000);
+  }
+
   $(document).on('click','.amcb-next',function(e){ e.preventDefault();
-    const step = parseInt($('.amcb-checkout-wizard').attr('data-step'),10) + 1; goto(step);
+    const step = parseInt($('.amcb-checkout-wizard').attr('data-step'),10);
+    if(step === 4){
+      const ctx = getContext();
+      ctx._wpnonce = amcbCheckout.nonce;
+      fetch(amcbCheckout.prepareUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(ctx)
+      }).then(r => {
+        if(r.status === 422){
+          return r.json().then(data => Promise.reject(data));
+        }
+        return r.json();
+      }).then(data => {
+        if(data.hold_expires_at){ startHoldCountdown(data.hold_expires_at); }
+        goto(step + 1);
+      }).catch(err => {
+        let msg = err?.message;
+        if(err?.code === 'NO_AVAILABILITY'){
+          msg = __('Selected vehicle unavailable for chosen dates.','amcb');
+        } else if(err?.code === 'LENGTH_ERROR'){
+          msg = __('Rental length outside allowed range.','amcb');
+        }
+        if(!msg){
+          msg = __('Selected vehicle unavailable or rental length invalid.','amcb');
+        }
+        alert(msg);
+      });
+      return;
+    }
+    goto(step + 1);
   });
   $(document).on('click','.amcb-prev',function(e){ e.preventDefault();
     const step = Math.max(1, parseInt($('.amcb-checkout-wizard').attr('data-step'),10) - 1); goto(step);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -67,13 +67,20 @@ class Plugin {
 		$ver = '0.1.0';
 		wp_register_style( 'amcb-frontend', plugins_url( '../assets/css/frontend.css', __FILE__ ), array(), $ver );
 		wp_register_script( 'amcb-frontend', plugins_url( '../assets/js/frontend.js', __FILE__ ), array( 'jquery' ), $ver, true );
-		wp_register_script( 'amcb-checkout', plugins_url( '../assets/js/checkout.js', __FILE__ ), array( 'jquery' ), $ver, true );
+		wp_register_script(
+			'amcb-checkout',
+			plugins_url( '../assets/js/checkout.js', __FILE__ ),
+			array( 'jquery', 'wp-i18n' ),
+			$ver,
+			true
+		);
 		wp_localize_script(
 			'amcb-checkout',
 			'amcbCheckout',
 			array(
-				'restUrl' => esc_url_raw( rest_url( 'amcb/v1/checkout/price' ) ),
-				'nonce'   => wp_create_nonce( 'wp_rest' ),
+				'restUrl'    => esc_url_raw( rest_url( 'amcb/v1/checkout/price' ) ),
+				'prepareUrl' => esc_url_raw( rest_url( 'amcb/v1/checkout/prepare' ) ),
+				'nonce'      => wp_create_nonce( 'wp_rest' ),
 			)
 		);
 	}


### PR DESCRIPTION
## Summary
- localize checkout scripts with prepareUrl and i18n support
- initiate /prepare request and hold countdown on confirm
- show session expiry timer and handle availability or length errors

## Testing
- `vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Plugin.php assets/js/checkout.js`


------
https://chatgpt.com/codex/tasks/task_e_689f4d5b9ea88333bf684730eb8d909e