### PR TITLE
feat: add dynamic season repeater for vehicles

### DIFF
--- a/assets/js/admin-vehicles.js
+++ b/assets/js/admin-vehicles.js
@@ -1,0 +1,23 @@
+(function($){
+let seasonIndex = 0;
+
+function addSeason() {
+let template = $('#amcb-season-template').html();
+template = template.replace(/__index__/g, seasonIndex).replace(/__number__/g, seasonIndex + 1);
+$('#amcb_seasons_container').append(template);
+seasonIndex++;
+}
+
+$(document).on('click', '#amcb_add_season', function(e){
+e.preventDefault();
+addSeason();
+});
+
+$(document).on('click', '.amcb-remove-season', function(){
+$(this).closest('.amcb-season-row').remove();
+});
+
+$(function(){
+addSeason();
+});
+})(jQuery);


### PR DESCRIPTION
## Summary
- replace fixed PHP season fields with a JS-driven repeater and Add season button
- iterate and sanitize posted season ranges before inserting vehicle prices

## Testing
- `~/.local/share/mise/installs/php/8.3.24/.composer/vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Admin/Vehicles.php assets/js/admin-vehicles.js`


------
https://chatgpt.com/codex/tasks/task_e_689f57247554833387307ae78415870b