### PR TITLE
feat: add payment fields to bookings

### DIFF
--- a/src/Install/DemoSeeder.php
+++ b/src/Install/DemoSeeder.php
@@ -43,6 +43,7 @@ class DemoSeeder {
                 $service_table   = $wpdb->prefix . 'amcb_services';
                 $coupon_table    = $wpdb->prefix . 'amcb_coupons';
                 $location_table  = $wpdb->prefix . 'amcb_locations';
+                $booking_table   = $wpdb->prefix . 'amcb_bookings';
 
 		// Vehicles.
                 $vehicles = array(
@@ -319,6 +320,11 @@ class DemoSeeder {
                        }
                }
 
-                return;
-        }
+               // Ensure new booking payment columns have NULL defaults.
+               $wpdb->query(
+                       "UPDATE {$booking_table} SET payment_intent_id = NULL, paid_amount = NULL, payment_method = NULL, receipt_url = NULL WHERE 1=1"
+               );
+
+               return;
+       }
 }

--- a/src/Install/Migrations.php
+++ b/src/Install/Migrations.php
@@ -14,13 +14,14 @@ class Migrations {
         /**
          * Current database schema version.
          *
-         * Versions:
-         * - 1.1.0 Initial schema.
-         * - 1.2.0 Added hold_until column to bookings table.
-         *
-         * @var string
-         */
-        const DB_VERSION = '1.2.0';
+        * Versions:
+        * - 1.1.0 Initial schema.
+        * - 1.2.0 Added hold_until column to bookings table.
+        * - 1.3.0 Added payment columns to bookings table.
+        *
+        * @var string
+        */
+        const DB_VERSION = '1.3.0';
 
 	/**
 	 * Retrieve SQL table schemas.
@@ -105,6 +106,10 @@ class Migrations {
             pickup_id bigint(20) unsigned NOT NULL DEFAULT 0,
             dropoff_id bigint(20) unsigned NOT NULL DEFAULT 0,
             hold_until datetime DEFAULT NULL,
+            payment_intent_id varchar(191) DEFAULT NULL,
+            paid_amount decimal(10,2) DEFAULT NULL,
+            payment_method varchar(50) DEFAULT NULL,
+            receipt_url varchar(191) DEFAULT NULL,
             created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
             updated_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             PRIMARY KEY  (id),


### PR DESCRIPTION
## Summary
- track Stripe payment details on bookings
- seed demo data with payment fields set to NULL

## Testing
- `./vendor/bin/phpcs -p --standard=WordPress --extensions=php src/Install/Migrations.php src/Install/DemoSeeder.php`


------
https://chatgpt.com/codex/tasks/task_e_689f6b5a49688333a93561c69119289e